### PR TITLE
feat: allow to force using old scanning way in LiteOn plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ This unofficial version adds the following changes from upstream **v0.8.0**:
 - Fix erroneous detection of finalized BD-R as BD-ROM
 - Fix read speed computation under high-speed BD drives (`gettimeofday` resolution was not enough, replaced with `clock_gettime`), closes [#1](https://github.com/speed47/qpxtool/issues/1)
 - Fix some drives having only the maximum read speed available, closes [#2](https://github.com/speed47/qpxtool/issues/2)
+- Add a way to force the old LiteOn scanning way (by setting the `LITEON_FORCE_OLD=1` env var)
 - Fix a few coding errors (thanks to compiler warnings)

--- a/plugins/liteon/qscan_cmd.cpp
+++ b/plugins/liteon/qscan_cmd.cpp
@@ -88,6 +88,12 @@ int scan_liteon::cmd_cd_errc_init_new() {
 }
 
 int scan_liteon::cmd_cd_errc_init() {
+	const char *liteon_force_old = getenv("LITEON_FORCE_OLD");
+	if (liteon_force_old && strcmp(liteon_force_old, "1") == 0) {
+		printf(COL_GRN "LiteOn: forced old CD ERRC commands" COL_NORM "\n");
+		cd_errc_new = false;
+		return cmd_cd_errc_init_old();
+	}
 	cd_errc_new = true;
 	if (cmd_cd_errc_init_new())
 		return cmd_cd_errc_init_old();


### PR DESCRIPTION
by setting env var `LITEON_FORCE_OLD=1`