### PR TITLE
f1tattoo: small fixes

### DIFF
--- a/console/f1tattoo/f1tattoo.cpp
+++ b/console/f1tattoo/f1tattoo.cpp
@@ -468,7 +468,7 @@ int main(int argc, char* argv[])
 			printf("%s: writing T@2 test image...\n", device);
 			yamaha_f1_do_tattoo(drive, NULL, 0);
 		} else {
-			tattoof = fopen(tattoofn, "r");
+			tattoof = fopen(tattoofn, "rb");
 			if (!tattoof) {
 				printf("Can't open tattoo file: %s", tattoofn);
 			} else {

--- a/console/f1tattoo/f1tattoo.cpp
+++ b/console/f1tattoo/f1tattoo.cpp
@@ -155,29 +155,29 @@ bool tattoo_read_png(unsigned char *buf, int rows, FILE *fp)
 	if (fread(header, 1, 8, fp) < 8) {
 		printf("Error reading PNG header\n");
 		fclose(fp);	
-		return 1;
+		return 0;
 	}
 	if (png_sig_cmp(header, 0, 8)) {
 		printf("File not recognized as a PNG\n");
 		fclose(fp);
-		return 1;
+		return 0;
 	}
 	png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);	
 	if (!png_ptr) {
 		printf("png_create_read_struct failed!\n");
 		fclose(fp);
-		return 1;
+		return 0;
 	}
 	info_ptr = png_create_info_struct(png_ptr);
 	if (!info_ptr) {
 		printf("png_create_info_struct failed!\n");
 		fclose(fp);
-		return 1;
+		return 0;
 	}
 	if (setjmp(png_jmpbuf(png_ptr))) {
 		printf("png_jmpbuf failed!\n");
 		fclose(fp);
-		return 1;
+		return 0;
 	}
 
 	png_init_io(png_ptr, fp);
@@ -191,7 +191,7 @@ bool tattoo_read_png(unsigned char *buf, int rows, FILE *fp)
 
 	if (my_png_get_image_width(png_ptr, info_ptr) != 3744U || my_png_get_image_height(png_ptr, info_ptr) != rows ) {
 		printf("Image should be 3744 x %ld", long(rows));
-		return 1;
+		return 0;
 	}
 
 //	width = info_ptr->width;
@@ -337,7 +337,7 @@ void usage(char* bin) {
 	printf("\t-s, --supported              show features supported by drive\n");
 	printf("\t--tattoo-raw <tattoo_file>   burn selected RAW image as DiscT@2\n");
 	printf("\t--tattoo-png <tattoo_file>   burn selected PNG image as DiscT@2\n");
-#ifdef USE_LIBPNG
+#ifndef USE_LIBPNG
 	printf("\t                             WARNING: f1tattoo compiled without libpng\n");
 #endif
 	printf("\t--tattoo-test                burn tattoo test image\n");

--- a/console/f1tattoo/f1tattoo.cpp
+++ b/console/f1tattoo/f1tattoo.cpp
@@ -325,7 +325,7 @@ err_read_png:
 #endif
 
 void usage(char* bin) {
-	fprintf (stderr,"\nusage: %s [-d device] [optinos]\n",bin);
+	fprintf (stderr,"\nusage: %s [-d device] [options]\n",bin);
 #ifdef USE_LIBPNG
 	printf("PNG support: YES\n");
 #else


### PR DESCRIPTION
Hey, here are some fixes for the f1tattoo console app.
- Some return values were incorrect in `tattoo_read_png()`.
- `#ifdef USE_LIBPNG` should be replaced by `#ifndef USE_LIBPNG` to get the warning message properly displayed when f1tattoo is compiled with libpng or not.
- `fread()` worked on linux but not on mingw because `fopen()` was not set to open the file in binary mode.